### PR TITLE
added the cart total and corrected the view of the cart

### DIFF
--- a/src/cart/index.html
+++ b/src/cart/index.html
@@ -91,6 +91,9 @@
           </li> -->
         </ul>
       </section>
+      <div class="cart-footer hide">
+        <p class="cart-total">Total:</p>
+      </div>
     </main>
 
     <footer>&copy;NOT a real business</footer>

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -173,6 +173,7 @@ button {
   font-size: var(--small-font);
   /* max-height: 120px; */
   align-items: center;
+  width: 100%;
 }
 
 .cart-card__image {
@@ -200,6 +201,25 @@ button {
 .cart-card__price {
   grid-row: 2;
   grid-column: 3;
+}
+
+.hide{
+  display: none;
+}
+.show{
+  display: block;
+}
+.cart-footer{
+  padding: 0.5em;
+}
+.cart-total{
+  display: flex;
+  justify-content: center;
+  font-size: 1.5em;
+  font-weight: bold;
+}
+.cart-total span{
+  margin: 0 1.5em;
 }
 
 @media screen and (min-width: 500px) {

--- a/src/js/cart.js
+++ b/src/js/cart.js
@@ -1,10 +1,16 @@
 import { getLocalStorage } from "./utils.mjs";
+const cartItems = getLocalStorage("so-cart");
+const cartSection = document.querySelector(".cart-footer");
+const cartTotalElement = document.querySelector(".cart-total");
 
+
+let cartTotal = 0
 function renderCartContents() {
-  const cartItems = getLocalStorage("so-cart");
   if(cartItems){
     const htmlItems = cartItems.map((item) => cartItemTemplate(item));
     document.querySelector(".product-list").innerHTML = htmlItems.join("");
+    calculateTotal();
+    renderCartTotal();
   }else{
     document.querySelector(".product-list").innerHTML = "<p>The cart is empty<span style='font-size:25px;'>&#128549;</span></p>"
   }
@@ -29,4 +35,16 @@ function cartItemTemplate(item) {
   return newItem;
 }
 
+function calculateTotal(){
+  let cartItemsPrices = [];
+  cartItems.forEach(item => {
+    cartItemsPrices.push(item.FinalPrice)
+  });
+  cartTotal = cartItemsPrices.reduce((a, b) => (a + b), 0);
+}
+function renderCartTotal(){
+  cartTotalElement.innerHTML = `Total: <span>$${cartTotal}</span`;
+  cartSection.classList.add("show")
+  cartSection.classList.remove("hide")
+}
 renderCartContents();


### PR DESCRIPTION
When items are added to the cart, the total amount is displayed. I used local storage to get the items and their corresponding prices, added those to an array and then used the reduced method to calculate the total. I added a function that renders the total only if there are any items in the cart. The HTML element has a class of "hide" that its only changed to "show" when there are items in the cart, allowing the total to be displayed. I also changed the width of the "li" elements where the items are displayed in the cart page, to ensure that the items can be viewed uniformed.